### PR TITLE
Fix memory leak: UnsignedInt_FromPyObject() in modint.hpp

### DIFF
--- a/atcoder/modint.hpp
+++ b/atcoder/modint.hpp
@@ -93,7 +93,14 @@ UnsignedInt_FromPyObject(PyObject *o)
 {
     long v;
     if (PyLong_Check(o)){
-        v = PyLong_AsLong(PyNumber_Remainder(o, PyLong_FromUnsignedLong((unsigned long)ModIntObject::mod)));
+        PyObject *py_mod;
+        py_mod = PyLong_FromUnsignedLong((unsigned long)ModIntObject::mod);
+        if (!py_mod) return (unsigned int)-1;
+        o = PyNumber_Remainder(o, py_mod);
+        Py_DECREF(py_mod);
+        if (!o) return (unsigned int)-1;
+        v = PyLong_AsLong(o);
+        Py_DECREF(o);
     } else {
         v = (long)ModInt_AsUnsignedInt(o);
     }


### PR DESCRIPTION
メモリリークしているっぽい箇所を修正しました。また、エラー時には -1 を unsigned int にキャストした値を返すようにしています。呼び出し側で別途エラーチェックを行う必要があるかもしれません。

備考：この修正により、若干パフォーマンスが落ちる可能性があります。